### PR TITLE
docs: clarify neighbor count

### DIFF
--- a/src/pathfinding/NavigationGrid.js
+++ b/src/pathfinding/NavigationGrid.js
@@ -144,7 +144,8 @@ export class NavigationGrid {
     }
     
     /**
-     * Get neighbors of a cell (8-directional)
+     * Get neighbors of a cell. Returns four cardinal neighbors by default,
+     * and includes diagonal neighbors when allowDiagonal is true.
      */
     getNeighbors(x, y, allowDiagonal = true) {
         const neighbors = [];


### PR DESCRIPTION
## Summary
- clarify that `getNeighbors` returns four neighbors by default and adds diagonals when `allowDiagonal` is true

## Testing
- `npm test` *(fails: multiple unit tests including ECS World, AStar, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4879900083328859e78f23a2b848