### PR TITLE
Fix texture cache iteration in GPU monitor

### DIFF
--- a/src/utils/GPUMemoryMonitor.js
+++ b/src/utils/GPUMemoryMonitor.js
@@ -100,8 +100,9 @@ export class GPUMemoryMonitor {
         let textureMemory = 0;
         let activeTextures = 0;
         
-        // Iterate through PIXI texture cache
-        for (const [url, texture] of PIXI.TextureCache) {
+        // Iterate through PIXI texture cache safely
+        const textureCache = PIXI.utils?.TextureCache || PIXI.TextureCache || {};
+        for (const texture of Object.values(textureCache)) {
             if (texture && texture.baseTexture && texture.baseTexture.valid) {
                 const baseTexture = texture.baseTexture;
                 const bytes = baseTexture.width * baseTexture.height * 4; // RGBA
@@ -137,6 +138,8 @@ export class GPUMemoryMonitor {
         
         // Trigger memory pressure callbacks if needed
         this.checkMemoryPressure(memoryPressure);
+
+        return this.memoryStats;
     }
     
     /**


### PR DESCRIPTION
## Summary
- Avoid TypeErrors by iterating PIXI texture cache via `Object.values` and support both `PIXI.utils.TextureCache` and `PIXI.TextureCache`
- Return updated stats from `updateMemoryStats`

## Testing
- `npm test` *(fails: expect(received).toBeInstanceOf(expected))*
- `npm run lint` *(fails: 169 errors, 1144 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4877f99c8332a57ee8acfb052b5b