### PR TITLE
fix: correct localStorage error key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -503,7 +503,7 @@ class CommandAndIndependentThought {
 // Global error logging to localStorage
 function logError(error, context = "unknown") {
     try {
-        const errors = JSON.parse(localStorage.getItem("comandind_errors") || "[]");
+        const errors = JSON.parse(localStorage.getItem("commandind_errors") || "[]");
         errors.push({
             timestamp: new Date().toISOString(),
             message: error.message || "Unknown error",
@@ -518,7 +518,7 @@ function logError(error, context = "unknown") {
             errors.splice(0, errors.length - 10);
         }
         
-        localStorage.setItem("comandind_errors", JSON.stringify(errors));
+        localStorage.setItem("commandind_errors", JSON.stringify(errors));
         console.error(`[${context}] Error logged:`, error);
     } catch (logError) {
         console.error("Failed to log error:", logError);

--- a/src/test/SecurityValidation.js
+++ b/src/test/SecurityValidation.js
@@ -259,7 +259,7 @@ class SecurityValidation {
             
             // Check if multiple error storage keys exist (should be consolidated)
             let legacyKeys = 0;
-            ['emergency_errors', 'game_errors_latest', 'game_errors_persistent', 'comandind_errors'].forEach(key => {
+            ['emergency_errors', 'game_errors_latest', 'game_errors_persistent', 'commandind_errors'].forEach(key => {
                 if (localStorage.getItem(key)) legacyKeys++;
             });
             

--- a/tests/diagnostics/error-catcher.html
+++ b/tests/diagnostics/error-catcher.html
@@ -124,7 +124,7 @@
             } else {
                 // Fallback to check various storage keys
                 try {
-                    const sources = ['secure_errors_data', 'comandind_errors', 'emergency_errors'];
+                    const sources = ['secure_errors_data', 'commandind_errors', 'emergency_errors'];
                     sources.forEach(source => {
                         const stored = localStorage.getItem(source);
                         if (stored) {

--- a/tests/diagnostics/errors.html
+++ b/tests/diagnostics/errors.html
@@ -115,7 +115,7 @@
                     'game_errors_latest', 
                     'game_errors_persistent',
                     'last_emergency_error',
-                    'comandind_errors'
+                    'commandind_errors'
                 ];
                 
                 sources.forEach(source => {
@@ -225,7 +225,7 @@
                     'game_errors_latest', 
                     'game_errors_persistent',
                     'last_emergency_error',
-                    'comandind_errors'
+                    'commandind_errors'
                 ];
                 
                 sources.forEach(source => {


### PR DESCRIPTION
## Summary
- fix misspelled localStorage key used for error logging
- update tests and diagnostics to reference the corrected key

## Testing
- `npm test` (fails: ECS World, RewardCalculator, NetworkManager, AStar tests)

------
https://chatgpt.com/codex/tasks/task_e_68ae4874cf1083328d02150c2ebb39e6